### PR TITLE
Fix meta `name` and `property` issue

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -9,14 +9,30 @@ export const parseOpenGraph = (htmlText: string): OpenGraph => {
   if (!description) {
     description = html.querySelector("meta[name='Description']");
   }
-  const ogTitle = html.querySelector("meta[property='og:title']");
-  const ogDescription = html.querySelector("meta[property='og:description']");
-  const ogImage = html.querySelector("meta[property='og:image']");
-  const ogUrl = html.querySelector("meta[property='og:url']");
-  const twitterTitle = html.querySelector("meta[name='twitter:title']");
-  const twitterDescription = html.querySelector("meta[name='twitter:description']");
-  const twitterImage = html.querySelector("meta[name='twitter:image']");
-  const twitterCard = html.querySelector("meta[name='twitter:card']");
+  const ogTitle = html.querySelector("meta[property='og:title']")
+    ? html.querySelector("meta[property='og:title']")
+    : html.querySelector("meta[name='og:title']");
+  const ogDescription = html.querySelector("meta[property='og:description']")
+    ? html.querySelector("meta[property='og:description']")
+    : html.querySelector("meta[name='og:description']");
+  const ogImage = html.querySelector("meta[property='og:image']")
+    ? html.querySelector("meta[property='og:image']")
+    : html.querySelector("meta[name='og:image']");
+  const ogUrl = html.querySelector("meta[property='og:url']")
+    ? html.querySelector("meta[property='og:url']")
+    : html.querySelector("meta[name='og:url']");
+  const twitterTitle = html.querySelector("meta[name='twitter:title']")
+    ? html.querySelector("meta[name='twitter:title']")
+    : html.querySelector("meta[property='twitter:title']");
+  const twitterDescription = html.querySelector("meta[name='twitter:description']")
+    ? html.querySelector("meta[name='twitter:description']")
+    : html.querySelector("meta[property='twitter:description']");
+  const twitterImage = html.querySelector("meta[name='twitter:image']")
+    ? html.querySelector("meta[name='twitter:image']")
+    : html.querySelector("meta[property='twitter:image']");
+  const twitterCard = html.querySelector("meta[name='twitter:card']")
+    ? html.querySelector("meta[name='twitter:card']")
+    : html.querySelector("meta[property='twitter:card']");
   return {
     title,
     description: description?.getAttribute("content") || NONE,


### PR DESCRIPTION
Some websites use the `name` or `property` attributes in their meta tags, but they don't always apply 'property' for Open Graph or 'name' for Twitter tags. To address this issue, I've added a condition in code.

![CleanShot 2023-12-19 at 20 42 47@2x](https://github.com/davidho0403/raycast-open-graph/assets/92412722/dfde7d66-5bb4-4ed2-ba57-299921d79da3)

![CleanShot 2023-12-19 at 20 42 31@2x](https://github.com/davidho0403/raycast-open-graph/assets/92412722/62de99a3-75b2-4035-8616-3d4e420e8eb9)
